### PR TITLE
Bring back and improve text for docket sheet buttons #51.

### DIFF
--- a/docassemble/juvenilesealing/data/questions/petitioner-entrypoint-10.yml
+++ b/docassemble/juvenilesealing/data/questions/petitioner-entrypoint-10.yml
@@ -202,12 +202,12 @@ subquestion: |
   an area where the paper is raised up in the shape of the
   seal.
 
-  Do you want to get certified copies of your docket sheets before
-  filling out the form to seal your records?
+  Do you want to find out how to get certified copies
+  of your docket sheets?
 
 buttons:
-  - Yes, show me how to get my certified docket sheets ${exit_icon}: True
-  - No, I want to keep going ${next_icon}: False
+  - Yes, tell me more: True
+  - No, take me back to the form: False
 ---
 id: end_without_finishing
 event: not_finishing_end


### PR DESCRIPTION
The old 'No' button actually had text that was confusing in the context of the new text. Also, the exit icon wasn't appropriate for the 'Yes' button.

Should they just be 'Yes' and 'No' at this point? The question at the bottom seems clear enough. Would it help to add a horizontal line before that last question?