### PR TITLE
Set up github actions for our chai/puppeteer tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   aloe-tests:
     runs-on: ubuntu-latest
 
-    name: Run tests
+    name: Run Aloe tests
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
@@ -18,8 +18,10 @@ jobs:
       matrix:
         node-version: [12.x]
 
-    name: Run tests
+    name: Run Puppeteer tests
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Setup environment
         env: 
           PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,29 @@
 on: [push]
 
 jobs:
-  aloe_tests:
+  tests:
     runs-on: ubuntu-latest
-    name: Run aloe tests
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    name: Run Aloe tests
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Aloe tests
+      - name: Run tests
         uses: ./tests # Uses an action in the root directory
+    name: Run Puppeteer tests
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        env: 
+          PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
+          PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,26 @@
 on: [push]
 
 jobs:
-  tests:
+  aloe-tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-
-    name: Run Aloe tests
+    name: Run tests
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
         uses: ./tests # Uses an action in the root directory
-    name: Run Puppeteer tests
+  puppeteer-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    name: Run tests
     steps:
-      - name: Run tests
+      - name: Setup environment
         env: 
           PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
           PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup environment
-        env: 
-          PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
-          PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
+          env: 
+            PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
+            PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Run tests
         uses: ./tests # Uses an action in the root directory
     name: Run Puppeteer tests
-      - name: Checkout
-        uses: actions/checkout@v2
+    steps:
       - name: Run tests
         env: 
           PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ jobs:
       matrix:
         node-version: [12.x]
 
+    env: 
+      PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
+      PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}
+
     name: Run Puppeteer tests
     steps:
       - name: Checkout
@@ -28,6 +32,3 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
-          env: 
-            PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
-            PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/chromedriver
 *__pycache__*
 node_modules*
 .env
+npm-debug.log

--- a/tests/puppeteer-utils.js
+++ b/tests/puppeteer-utils.js
@@ -1,16 +1,15 @@
 const puppeteer = require('puppeteer');
-const dotenv = require('dotenv');
+require('dotenv').config();
 
 const login = async () => {
-  const result = dotenv.config().parsed;
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   // Login
   await page.goto('https://interviews-dev.gbls.org/user/sign-in?');
   const emailElement = await page.$('#email');
-  await emailElement.type(result.PLAYGROUND_EMAIL);
+  await emailElement.type(process.env.PLAYGROUND_EMAIL);
   const passwordElement = await page.$('#password');
-  await passwordElement.type(result.PLAYGROUND_PASSWORD);
+  await passwordElement.type(process.env.PLAYGROUND_PASSWORD);
   await Promise.all([
     passwordElement.press('Enter'),
     page.waitForNavigation(),

--- a/tests/puppeteer-utils.js
+++ b/tests/puppeteer-utils.js
@@ -7,6 +7,7 @@ const login = async () => {
   // Login
   await page.goto('https://interviews-dev.gbls.org/user/sign-in?');
   const emailElement = await page.$('#email');
+  console.log(process.env.PLAYGROUND_EMAIL)
   await emailElement.type(process.env.PLAYGROUND_EMAIL);
   const passwordElement = await page.$('#password');
   await passwordElement.type(process.env.PLAYGROUND_PASSWORD);

--- a/tests/puppeteer-utils.js
+++ b/tests/puppeteer-utils.js
@@ -7,7 +7,6 @@ const login = async () => {
   // Login
   await page.goto('https://interviews-dev.gbls.org/user/sign-in?');
   const emailElement = await page.$('#email');
-  console.log(process.env.PLAYGROUND_EMAIL)
   await emailElement.type(process.env.PLAYGROUND_EMAIL);
   const passwordElement = await page.$('#password');
   await passwordElement.type(process.env.PLAYGROUND_PASSWORD);

--- a/tests/sample-chai-assertions.js
+++ b/tests/sample-chai-assertions.js
@@ -1,5 +1,4 @@
 const chai = require('chai');
-const puppeteer = require('puppeteer');
 const puppeteerutils = require('./puppeteer-utils');
 
 // Tell Chai that we want to use the expect syntax


### PR DESCRIPTION
#80 

This adds a new step to our Github workflow to run `npm run test`, which currently runs our puppeteer tests. This required adding `PLAYGROUND_EMAIL` and `PLAYGROUND_PASSWORD` environment variables to the workflow using the [GitHub Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) feature.